### PR TITLE
System mapping changed

### DIFF
--- a/src/engine/graphic/GRBar.cpp
+++ b/src/engine/graphic/GRBar.cpp
@@ -154,7 +154,7 @@ void GRBar::GGSOutput() const
 */
 void GRBar::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoBar)
+	if (sel == kGuidoBar || sel == kGuidoBarAndEvent)
 		SendMap (f, getRelativeTimePosition(), getDuration(), kBar, infos);
 }
 

--- a/src/engine/graphic/GRCluster.cpp
+++ b/src/engine/graphic/GRCluster.cpp
@@ -239,6 +239,6 @@ ARCluster *GRCluster::getARCluster() const
 
 void GRCluster::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent || kGuidoBarAndEvent)
+	if (sel == kGuidoEvent || sel == kGuidoBarAndEvent)
         SendMap(f, firstNote->getARNote()->getStartTimePosition(), fDuration, kNote, infos);
 }

--- a/src/engine/graphic/GRCluster.cpp
+++ b/src/engine/graphic/GRCluster.cpp
@@ -239,6 +239,6 @@ ARCluster *GRCluster::getARCluster() const
 
 void GRCluster::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent)
+	if (sel == kGuidoEvent || kGuidoBarAndEvent)
         SendMap(f, firstNote->getARNote()->getStartTimePosition(), fDuration, kNote, infos);
 }

--- a/src/engine/graphic/GREmpty.cpp
+++ b/src/engine/graphic/GREmpty.cpp
@@ -41,7 +41,7 @@ GREmpty::~GREmpty()	{}
 
 void GREmpty::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent) {
+	if (sel == kGuidoEvent || kGuidoBarAndEvent) {
 		SendMap (f, getRelativeTimePosition(), getDuration(), kEmpty, infos);
 	}
 }

--- a/src/engine/graphic/GREmpty.cpp
+++ b/src/engine/graphic/GREmpty.cpp
@@ -41,7 +41,7 @@ GREmpty::~GREmpty()	{}
 
 void GREmpty::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent || kGuidoBarAndEvent) {
+	if (sel == kGuidoEvent || sel == kGuidoBarAndEvent) {
 		SendMap (f, getRelativeTimePosition(), getDuration(), kEmpty, infos);
 	}
 }

--- a/src/engine/graphic/GRRepeatBegin.cpp
+++ b/src/engine/graphic/GRRepeatBegin.cpp
@@ -95,7 +95,7 @@ void GRRepeatBegin::updateBoundingBox()
 */
 void GRRepeatBegin::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoBar)
+	if (sel == kGuidoBar || sel == kGuidoBarAndEvent)
 		SendMap (f, getRelativeTimePosition(), getDuration(), kRepeatBegin, infos);
 }
 

--- a/src/engine/graphic/GRRepeatEnd.cpp
+++ b/src/engine/graphic/GRRepeatEnd.cpp
@@ -101,7 +101,7 @@ void GRRepeatEnd::setHPosition(float nx)
 */
 void GRRepeatEnd::GetMap(GuidoElementSelector sel, MapCollector& f, MapInfos& infos) const
 {
-	if (sel == kGuidoBar)
+	if (sel == kGuidoBar || sel == kGuidoBarAndEvent)
 		SendMap (f, getRelativeTimePosition(), getDuration(), kRepeatEnd, infos);
 }
 

--- a/src/engine/graphic/GRSingleNote.cpp
+++ b/src/engine/graphic/GRSingleNote.cpp
@@ -186,7 +186,7 @@ void GRSingleNote::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& 
         if (this == fCluster->getFirstNote())
             fCluster->GetMap(sel, f, infos);
     }
-    else if (sel == kGuidoEvent || kGuidoBarAndEvent) {
+    else if (sel == kGuidoEvent || sel == kGuidoBarAndEvent) {
 		TYPE_DURATION dur = getDuration();
 		if (dur.getNumerator() == 0) {		// notes in chords have a null duration
 			dur = getDurTemplate();

--- a/src/engine/graphic/GRSingleNote.cpp
+++ b/src/engine/graphic/GRSingleNote.cpp
@@ -186,7 +186,7 @@ void GRSingleNote::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& 
         if (this == fCluster->getFirstNote())
             fCluster->GetMap(sel, f, infos);
     }
-    else if (sel == kGuidoEvent) {
+    else if (sel == kGuidoEvent || kGuidoBarAndEvent) {
 		TYPE_DURATION dur = getDuration();
 		if (dur.getNumerator() == 0) {		// notes in chords have a null duration
 			dur = getDurTemplate();

--- a/src/engine/graphic/GRSingleRest.cpp
+++ b/src/engine/graphic/GRSingleRest.cpp
@@ -233,7 +233,7 @@ void GRSingleRest::GGSOutput() const
 
 void GRSingleRest::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent || kGuidoBarAndEvent) {
+	if (sel == kGuidoEvent || sel == kGuidoBarAndEvent) {
 		SendMap (f, getRelativeTimePosition(), getDuration(), kRest, infos);
 	}
 }

--- a/src/engine/graphic/GRSingleRest.cpp
+++ b/src/engine/graphic/GRSingleRest.cpp
@@ -233,7 +233,7 @@ void GRSingleRest::GGSOutput() const
 
 void GRSingleRest::GetMap( GuidoElementSelector sel, MapCollector& f, MapInfos& infos ) const
 {
-	if (sel == kGuidoEvent) {
+	if (sel == kGuidoEvent || kGuidoBarAndEvent) {
 		SendMap (f, getRelativeTimePosition(), getDuration(), kRest, infos);
 	}
 }

--- a/src/engine/graphic/GRTrill.cpp
+++ b/src/engine/graphic/GRTrill.cpp
@@ -187,16 +187,18 @@ void GRTrill::OnDraw(VGDevice & hdc , float right, float noteY, int nVoice) cons
 		if (!begin) x -= mTagOffset.x;
 		else		left += mTagOffset.x;
 
-		while (left + widthOfTilde <= right) {
-			if (fDrawOnNoteHead)
-				GRNotationElement::OnDrawSymbol(hdc, kTilde, x, noteY - getPosition().y, mTagSize);
-			else
-				GRNotationElement::OnDrawSymbol(hdc, kTilde, x, 0, mTagSize);
-
-			x    += widthOfTilde;
-			left += widthOfTilde;
-		}
-		GRTrill::getLastPosX(nVoice) = left;		
+        if (widthOfTilde != 0) { // widthOfTilde may be 0 if font is not installed for example
+            while (left + widthOfTilde <= right) {
+                if (fDrawOnNoteHead)
+                    GRNotationElement::OnDrawSymbol(hdc, kTilde, x, noteY - getPosition().y, mTagSize);
+                else
+                    GRNotationElement::OnDrawSymbol(hdc, kTilde, x, 0, mTagSize);
+                
+                x    += widthOfTilde;
+                left += widthOfTilde;
+            }
+        }
+		GRTrill::getLastPosX(nVoice) = left;
 	}
     else {	
 		if (fShowTR) GRNotationElement::OnDraw(hdc);

--- a/src/engine/include/GUIDOScoreMap.h
+++ b/src/engine/include/GUIDOScoreMap.h
@@ -36,7 +36,7 @@
 //------------------------------------------------------------------------------
 // graphic elements selector definitions
 typedef enum { 
-	kGuidoPage, kGuidoSystem, kGuidoSystemSlice, kGuidoStaff, /*kGuidoMeasure,*/ kGuidoBar, kGuidoEvent, 
+	kGuidoPage, kGuidoSystem, kGuidoSystemSlice, kGuidoStaff, /*kGuidoMeasure,*/ kGuidoBar, kGuidoBarAndEvent, kGuidoEvent,
 	kGuidoScoreElementEnd
 } GuidoElementSelector;
 

--- a/src/engine/maps/GuidoMapCollector.cpp
+++ b/src/engine/maps/GuidoMapCollector.cpp
@@ -122,23 +122,23 @@ void GuidoVoiceAndBarCollector::Graph2TimeMap( const FloatRect& box, const TimeS
     if ( infos.type == kGraceNote)      return; // grace notes are filtered out
     
     // If current element is a rest, and previous one on the same staff is a bar, we adjust its bounding box
-    if (infos.type == kRest && prevBarX[infos.staffNum] != 0) {
+    if (infos.type == kRest && fPrevBarX[infos.staffNum] != 0) {
         // We check if we're after a line break
-        if (box.left < prevBarX[infos.staffNum]) {
+        if (box.left < fPrevBarX[infos.staffNum]) {
             // TODO: After a line break, we have to set the correct left rect value
-            prevBarX[infos.staffNum] = box.left; // For now, we don't change the olf rect left value
+            fPrevBarX[infos.staffNum] = box.left; // For now, we don't change the olf rect left value
         }
         
-        // We adjust new rect according to stored prevBarX and add new element
-        FloatRect newRect (prevBarX[infos.staffNum], box.top, box.right, box.bottom);
+        // We adjust new rect according to stored fPrevBarX and add new element
+        FloatRect newRect (fPrevBarX[infos.staffNum], box.top, box.right, box.bottom);
         add (dates, newRect);
     }
     // Otherwise, if element is not a bar, we directly add current dates/box to the list
     else if (!isBar)
         add (dates, box);
     
-    // We set prevBarX if current element is a bar, otherwise we reset it
-    prevBarX[infos.staffNum] = (isBar ? box.right : 0);
+    // We set fPrevBarX if current element is a bar, otherwise we reset it
+    fPrevBarX[infos.staffNum] = (isBar ? box.right : 0);
 }
 
 //----------------------------------------------------------------------

--- a/src/engine/maps/GuidoMapCollector.cpp
+++ b/src/engine/maps/GuidoMapCollector.cpp
@@ -300,31 +300,12 @@ void GuidoStaffCollector::process (int page, float w, float h, Time2GraphicMap* 
 		GuidoGetMap( fGRHandler, page, w, h, kGuidoStaff, *this );	// collect the staves map
 		sort (fMap.begin(), fMap.end(), scompare);					// sort by lines, smaller date first
 		mergelines (fMap, map);										// merge the graphic segments on a single line basis
-
-
-        // OLD BEHAVIOUR //
         
 		fNoEmpty = true;
 		fMap.clear();
 		GuidoGetMap( fGRHandler, page, w, h, kGuidoEvent, *this );	// collect the events map
 		sort (fMap.begin(), fMap.end(), mcompare);					// sort first date, smaller duration first
 		reduce (fMap, evmap);										// retains only one segment per starting date
-
-        /*****************/
-
-        
-        // NEW BEHAVIOUR - TODO //
-        ///> A rest between two bars has its segment box left value at its left barline x position
-        
-        //Time2GraphicMap tmpEvMap;
-        //GuidoVoiceAndBarCollector voiceAndBarCollector(fGRHandler/* VIRER */ /*, fStaffNum, fFilter*/);
-        //voiceAndBarCollector.process(page, w, h, &tmpEvMap);
-        //sort(tmpEvMap.begin(), tmpEvMap.end(), mcompare);
-        //reduce (tmpEvMap, evmap);
-        
-        /*****************/
-        
-        
         staffmerge (map, evmap, *outmap);							// and split the staff lines using the events segments
 	}
 }

--- a/src/engine/maps/GuidoMapCollector.h
+++ b/src/engine/maps/GuidoMapCollector.h
@@ -111,7 +111,7 @@ inline std::ostream& operator<< (std::ostream& os, const std::vector<std::pair<T
 
 //----------------------------------------------------------------------
 /*!
-	\brief a guido map collector adjusting system to to slices start
+	\brief a guido map collector adjusting system to slices start
 */
 class GuidoSystemCollector: public GuidoMapCollector
 {
@@ -125,6 +125,27 @@ class GuidoSystemCollector: public GuidoMapCollector
 		virtual void Graph2TimeMap( const FloatRect& box, const TimeSegment& dates,  const GuidoElementInfos& infos );
 		virtual void processNoDiv (int page, float w, float h, Time2GraphicMap* outmap);
 		virtual void process (int page, float w, float h, Time2GraphicMap* outmap);
+};
+
+//----------------------------------------------------------------------
+/*!
+ \brief a guido map collector retrieving the list of kNote/kRest events. For each
+        kRest starting a measure, its box left is aligned on the measure left barline.
+ */
+class GuidoVoiceAndBarCollector: public GuidoMapCollector
+{
+    typedef std::pair<TimeSegment, FloatRect>	TMapElt;
+    std::vector<TMapElt>	fMap;
+    
+    public :
+                 GuidoVoiceAndBarCollector(CGRHandler gr) : GuidoMapCollector(gr, kGuidoBarAndEvent) { }
+        virtual ~GuidoVoiceAndBarCollector() {}
+    
+        ///< overrides the method called by guido for each graphic segment
+        virtual void Graph2TimeMap( const FloatRect& box, const TimeSegment& dates,  const GuidoElementInfos& infos );
+    
+    private:
+        std::map<int,int> prevBarX; // Associates for each staffnum the x position of the previous bar, and 0 if previous element is not a bar
 };
 
 /*!@} */

--- a/src/engine/maps/GuidoMapCollector.h
+++ b/src/engine/maps/GuidoMapCollector.h
@@ -145,7 +145,7 @@ class GuidoVoiceAndBarCollector: public GuidoMapCollector
         virtual void Graph2TimeMap( const FloatRect& box, const TimeSegment& dates,  const GuidoElementInfos& infos );
     
     private:
-        std::map<int,int> prevBarX; // Associates for each staffnum the x position of the previous bar, and 0 if previous element is not a bar
+        std::map<int,int> fPrevBarX; // Associates for each staffnum the x position of the previous bar, and 0 if previous element is not a bar
 };
 
 /*!@} */


### PR DESCRIPTION
Now, if a rest begins a measure, its mapping is aligned with bar left. All concurrent events (at the same date) on other staves have their mapping aligned too.

For now, staves and system mapping are not consistent, since staff mapping has been left unchanged (TODO).

Validation:
- Several svg have changed because of the new behaviour, for bars starting with a rest.
- Some others changed because for each event at the same date over staves, the kept one is now the leftmost one.
- octavaBug.gmn: some event left box is at the left of the armor, which is not perfect, but solving this is not easy
- commented section "old behaviour" in GuidoSystemCollector::process passes validation process without any svg change if uncommented.

[validation_summary.txt](https://github.com/grame-cncm/guidolib/files/867271/validation_summary.txt)
