### PR TITLE
API method added to define each staff size scale

### DIFF
--- a/src/engine/graphic/GRMusic.cpp
+++ b/src/engine/graphic/GRMusic.cpp
@@ -656,6 +656,24 @@ void GRMusic::printVoices (std::ostream& os) const
 	}
 }
 
+/** \brief If given size is negative, we remove corresponding staff size in map
+ */
+void GRMusic::setStaffSize(int staffNum, float size) {
+    if (size < 0)
+        fStaffSizes.erase(staffNum);
+    else
+        fStaffSizes[staffNum] = size;
+}
+
+/** \brief If size of given staff is not set, we return -1.
+ */
+float GRMusic::getStaffSize(int staffNum) {
+    if (fStaffSizes.find(staffNum) == fStaffSizes.end())
+        return -1;
+    else
+        return fStaffSizes[staffNum];
+}
+
 //-------------------------------------------------------------------------------
 ARMusicalVoice* GRMusic::getARVoice (int n)
 {

--- a/src/engine/graphic/GRMusic.cpp
+++ b/src/engine/graphic/GRMusic.cpp
@@ -615,7 +615,7 @@ void GRMusic::createGR (const ARPageFormat * inPageFormat, const GuidoLayoutSett
 		GRVoice * grv = new GRVoice(arv, false);
 		mVoiceList.push_back(grv);
 	}
-	GRStaffManager grsm( this, fInFormat, &fSettings);
+	GRStaffManager grsm( this, fInFormat, &fSettings, &fStaffSizeScales);
 	grsm.createStaves();
 	fLyricsChecked = false;
 
@@ -654,6 +654,12 @@ void GRMusic::printVoices (std::ostream& os) const
 			}
 		}
 	}
+}
+
+//-------------------------------------------------------------------------------
+void GRMusic::setStaffScale (int staffNum, float sizeScale)
+{
+    fStaffSizeScales[staffNum] = sizeScale;
 }
 
 //-------------------------------------------------------------------------------

--- a/src/engine/graphic/GRMusic.cpp
+++ b/src/engine/graphic/GRMusic.cpp
@@ -615,7 +615,7 @@ void GRMusic::createGR (const ARPageFormat * inPageFormat, const GuidoLayoutSett
 		GRVoice * grv = new GRVoice(arv, false);
 		mVoiceList.push_back(grv);
 	}
-	GRStaffManager grsm( this, fInFormat, &fSettings, &fStaffSizeScales);
+	GRStaffManager grsm( this, fInFormat, &fSettings);
 	grsm.createStaves();
 	fLyricsChecked = false;
 
@@ -654,12 +654,6 @@ void GRMusic::printVoices (std::ostream& os) const
 			}
 		}
 	}
-}
-
-//-------------------------------------------------------------------------------
-void GRMusic::setStaffScale (int staffNum, float sizeScale)
-{
-    fStaffSizeScales[staffNum] = sizeScale;
 }
 
 //-------------------------------------------------------------------------------

--- a/src/engine/graphic/GRMusic.h
+++ b/src/engine/graphic/GRMusic.h
@@ -117,6 +117,8 @@ class GRMusic : public GREvent
 				void	removeAutoSpace (ARMusic * arm);// removes space tags inserted by checkLyricsCollisions()
 
 				void	printVoices (std::ostream& os) const;
+    
+                void    setStaffScale(int staffNum, float sizeScale);
 
 		std::vector<TCollisionInfo> getCollisions() const	{ return fCollisions.list(); }
 
@@ -138,6 +140,7 @@ class GRMusic : public GREvent
 
 		PageList			mPages;
 		ARPageFormat *		fInFormat;
+        std::map<int,float> fStaffSizeScales;
 		GuidoLayoutSettings fSettings;
 		TCollisions			fCollisions;
 		bool				fLyricsChecked;		// true when lyrics collisions have been solved

--- a/src/engine/graphic/GRMusic.h
+++ b/src/engine/graphic/GRMusic.h
@@ -118,9 +118,9 @@ class GRMusic : public GREvent
 
 				void	printVoices (std::ostream& os) const;
     
-                void    setStaffSizeScale(int staffNum, float sizeScale)    { fStaffSizeScales[staffNum] = sizeScale; }
-                float   getStaffSizeScale(int staffNum)                     { return fStaffSizeScales[staffNum]; }
-
+                void    setStaffSize(int staffNum, float size);
+                float   getStaffSize(int staffNum);
+    
 		std::vector<TCollisionInfo> getCollisions() const	{ return fCollisions.list(); }
 
 	protected:
@@ -141,7 +141,7 @@ class GRMusic : public GREvent
 
 		PageList			mPages;
 		ARPageFormat *		fInFormat;
-        std::map<int,float> fStaffSizeScales;
+        std::map<int,float> fStaffSizes;
 		GuidoLayoutSettings fSettings;
 		TCollisions			fCollisions;
 		bool				fLyricsChecked;		// true when lyrics collisions have been solved

--- a/src/engine/graphic/GRMusic.h
+++ b/src/engine/graphic/GRMusic.h
@@ -118,7 +118,8 @@ class GRMusic : public GREvent
 
 				void	printVoices (std::ostream& os) const;
     
-                void    setStaffScale(int staffNum, float sizeScale);
+                void    setStaffSizeScale(int staffNum, float sizeScale)    { fStaffSizeScales[staffNum] = sizeScale; }
+                float   getStaffSizeScale(int staffNum)                     { return fStaffSizeScales[staffNum]; }
 
 		std::vector<TCollisionInfo> getCollisions() const	{ return fCollisions.list(); }
 

--- a/src/engine/graphic/GRStaff.h
+++ b/src/engine/graphic/GRStaff.h
@@ -113,6 +113,8 @@ class GRStaffState
 		void			reset2key();
 
         float getYOffset() const                                { return yOffset; }
+    
+        void setSizeScale(float sizeScale)                      { staffLSPACE = LSPACE * sizeScale; }
 
 	protected:
 		// Meter-Parameters
@@ -293,6 +295,8 @@ class GRStaff : public GRCompositeNotationElement
 
 		void	setClefParameters(	GRClef * grclef, GRStaffState::clefstate cstate = GRStaffState::CLEFAUTO );
 		void	setMeterParameters( GRMeter * grmeter );
+    
+        void    setStaffSizeScale( float sizeScale )  { mStaffState.setSizeScale(sizeScale); }
 
 		GuidoPos 		lastrodpos;
 		GRRod * 		lastrod;

--- a/src/engine/graphic/GRStaff.h
+++ b/src/engine/graphic/GRStaff.h
@@ -114,7 +114,7 @@ class GRStaffState
 
         float getYOffset() const                                { return yOffset; }
     
-        void setSizeScale(float sizeScale)                      { staffLSPACE = LSPACE * sizeScale; }
+        void setStaffLSPACE(float value)                        { staffLSPACE = value * 2; } // Factor 2 to be consistent with GRStaff::setStaffFormat(ARStaffFormat * staffrmt)
 
 	protected:
 		// Meter-Parameters
@@ -296,7 +296,7 @@ class GRStaff : public GRCompositeNotationElement
 		void	setClefParameters(	GRClef * grclef, GRStaffState::clefstate cstate = GRStaffState::CLEFAUTO );
 		void	setMeterParameters( GRMeter * grmeter );
     
-        void    setStaffSizeScale( float sizeScale )  { mStaffState.setSizeScale(sizeScale); }
+        void    setStaffSize( float size )  { mStaffState.setStaffLSPACE(size); }
 
 		GuidoPos 		lastrodpos;
 		GRRod * 		lastrod;

--- a/src/engine/graphic/GRStaffManager.cpp
+++ b/src/engine/graphic/GRStaffManager.cpp
@@ -578,8 +578,8 @@ void GRStaffManager::prepareStaff(int staff)
 		}
 		mGrSystemSlice->addStaff(curstaff,staff);
         
-        // We apply potential staff scale defined with GuidoSetStaffSizeScale API call
-        applyStaffScale(curstaff, staff);
+        // We apply potential staff size defined with GuidoSetStaffSize API call
+        applyStaffSize(curstaff, staff);
 	}
 	// set the staff in  Vector mMyStaffs.
 	mMyStaffs->Set(staff, curstaff);
@@ -3371,8 +3371,8 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 			GRStaff * newstaff = new GRStaff(beginslice, settings.proportionalRenderingForceMultiplicator);
 			beginslice->addStaff(newstaff,i);
             
-            // We apply potential staff scale defined with GuidoSetStaffSizeScale API call
-            applyStaffScale(newstaff, i);
+            // We apply potential staff size defined with GuidoSetStaffSize API call
+            applyStaffSize(newstaff, i);
 			
 			// add the staffstate stuff ... the call to BeginStaff is done later, when we have
 			// determined the number of springs that are needed by the New-Elements!
@@ -3447,14 +3447,14 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 	return beginslice;
 }
 
-/** \brief Apply potential staff scale defined with GuidoSetStaffSizeScale API call
+/** \brief Apply potential staff size defined with GuidoSetStaffSize API call
     to given staff with given staff number.
  */
-void GRStaffManager::applyStaffScale(GRStaff *staff, int staffNum) {
-    float staffSizeScale = mGrMusic->getStaffSizeScale(staffNum);
+void GRStaffManager::applyStaffSize(GRStaff *staff, int staffNum) {
+    float staffSize = mGrMusic->getStaffSize(staffNum);
     
-    if (staffSizeScale != 0)
-        staff->setStaffSizeScale(staffSizeScale);
+    if (staffSize >= 0)
+        staff->setStaffSize(staffSize);
 }
 
 /** Take care of breaking at cnt (number of slices for the new system). 

--- a/src/engine/graphic/GRStaffManager.cpp
+++ b/src/engine/graphic/GRStaffManager.cpp
@@ -91,7 +91,7 @@ const bool kIsGiesekingSpacing = true;
 	The systems are created whenever real NewLines are 
 	encountered (or automatic once are introduced).
 */
-GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat, const GuidoLayoutSettings * aSettings)
+GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat, const GuidoLayoutSettings * aSettings, const std::map<int, float> * staffSizeScales)
 	: mSystemDistancePrev(-1.0f),
 	  mSystemDistance(-1.0f),
 	  staffposvect(0),
@@ -122,6 +122,9 @@ GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat,
 		// Apply default layout settings
 		GuidoGetDefaultLayoutSettings (&this->settings);
 	}
+    
+    if (staffSizeScales)
+        this->fStaffSizeScales = *staffSizeScales;
 
 	mIsBreak = false;
 	mArAuto  = NULL;
@@ -577,6 +580,9 @@ void GRStaffManager::prepareStaff(int staff)
 			}
 		}
 		mGrSystemSlice->addStaff(curstaff,staff);
+        
+        // We apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+        applyStaffScale(curstaff, staff);
 	}
 	// set the staff in  Vector mMyStaffs.
 	mMyStaffs->Set(staff, curstaff);
@@ -3367,6 +3373,9 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 			// The Staff-numbers are equal to the staff-vector at the breaktime.			
 			GRStaff * newstaff = new GRStaff(beginslice, settings.proportionalRenderingForceMultiplicator);
 			beginslice->addStaff(newstaff,i);
+            
+            // We apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+            applyStaffScale(newstaff, i);
 			
 			// add the staffstate stuff ... the call to BeginStaff is done later, when we have
 			// determined the number of springs that are needed by the New-Elements!
@@ -3439,6 +3448,14 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 		newForceFunc->addSpring(mSpringVector->Get(i));
 	}
 	return beginslice;
+}
+
+/** \brief Apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+    to given staff with given staff number.
+ */
+void GRStaffManager::applyStaffScale(GRStaff *staff, int staffNum) {
+    if (fStaffSizeScales[staffNum] != 0)
+        staff->getGRStaffState().staffLSPACE = LSPACE * fStaffSizeScales[staffNum];
 }
 
 /** Take care of breaking at cnt (number of slices for the new system). 

--- a/src/engine/graphic/GRStaffManager.cpp
+++ b/src/engine/graphic/GRStaffManager.cpp
@@ -91,7 +91,7 @@ const bool kIsGiesekingSpacing = true;
 	The systems are created whenever real NewLines are 
 	encountered (or automatic once are introduced).
 */
-GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat, const GuidoLayoutSettings * aSettings, const std::map<int, float> * staffSizeScales)
+GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat, const GuidoLayoutSettings * aSettings)
 	: mSystemDistancePrev(-1.0f),
 	  mSystemDistance(-1.0f),
 	  staffposvect(0),
@@ -122,9 +122,6 @@ GRStaffManager::GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat,
 		// Apply default layout settings
 		GuidoGetDefaultLayoutSettings (&this->settings);
 	}
-    
-    if (staffSizeScales)
-        this->fStaffSizeScales = *staffSizeScales;
 
 	mIsBreak = false;
 	mArAuto  = NULL;
@@ -581,7 +578,7 @@ void GRStaffManager::prepareStaff(int staff)
 		}
 		mGrSystemSlice->addStaff(curstaff,staff);
         
-        // We apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+        // We apply potential staff scale defined with GuidoSetStaffSizeScale API call
         applyStaffScale(curstaff, staff);
 	}
 	// set the staff in  Vector mMyStaffs.
@@ -3374,7 +3371,7 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 			GRStaff * newstaff = new GRStaff(beginslice, settings.proportionalRenderingForceMultiplicator);
 			beginslice->addStaff(newstaff,i);
             
-            // We apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+            // We apply potential staff scale defined with GuidoSetStaffSizeScale API call
             applyStaffScale(newstaff, i);
 			
 			// add the staffstate stuff ... the call to BeginStaff is done later, when we have
@@ -3450,12 +3447,14 @@ GRSystemSlice * GRStaffManager::CreateBeginSlice(const GRSystemSlice * lastslice
 	return beginslice;
 }
 
-/** \brief Apply potential staff scale defined with GuidoSetDefaultStaffFormat API call
+/** \brief Apply potential staff scale defined with GuidoSetStaffSizeScale API call
     to given staff with given staff number.
  */
 void GRStaffManager::applyStaffScale(GRStaff *staff, int staffNum) {
-    if (fStaffSizeScales[staffNum] != 0)
-        staff->getGRStaffState().staffLSPACE = LSPACE * fStaffSizeScales[staffNum];
+    float staffSizeScale = mGrMusic->getStaffSizeScale(staffNum);
+    
+    if (staffSizeScale != 0)
+        staff->setStaffSizeScale(staffSizeScale);
 }
 
 /** Take care of breaking at cnt (number of slices for the new system). 

--- a/src/engine/graphic/GRStaffManager.h
+++ b/src/engine/graphic/GRStaffManager.h
@@ -164,7 +164,7 @@ class GRStaffManager
 
 	public:
 
-				GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat = 0, const GuidoLayoutSettings * settings = 0);
+				GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat = 0, const GuidoLayoutSettings * settings = 0, const std::map<int, float> * staffSizeScales = 0);
         virtual ~GRStaffManager();
 
 		// this routine is used to get the current beginning_sff
@@ -322,6 +322,7 @@ class GRStaffManager
 		ARAuto *	mArAuto;
 		std::vector<ARAccolade	*> mCurAccoladeTag;
 		GuidoLayoutSettings settings;
+        std::map<int, float> fStaffSizeScales;
 	
 	private:
 		// the methods below are used by createStaves
@@ -340,6 +341,7 @@ class GRStaffManager
 		bool	nextTimePosition (int nvoices, bool filltagMode, TCreateStavesState& state);
 		float	systemBreak (int newlineMode, float beginheight);
 		int		initVoices(int cnt);
+        void    applyStaffScale(GRStaff *staff, int staffNum);
 };
 
 #endif

--- a/src/engine/graphic/GRStaffManager.h
+++ b/src/engine/graphic/GRStaffManager.h
@@ -164,7 +164,7 @@ class GRStaffManager
 
 	public:
 
-				GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat = 0, const GuidoLayoutSettings * settings = 0, const std::map<int, float> * staffSizeScales = 0);
+				GRStaffManager(GRMusic * p_grmusic, ARPageFormat * inPageFormat = 0, const GuidoLayoutSettings * settings = 0);
         virtual ~GRStaffManager();
 
 		// this routine is used to get the current beginning_sff
@@ -322,7 +322,6 @@ class GRStaffManager
 		ARAuto *	mArAuto;
 		std::vector<ARAccolade	*> mCurAccoladeTag;
 		GuidoLayoutSettings settings;
-        std::map<int, float> fStaffSizeScales;
 	
 	private:
 		// the methods below are used by createStaves

--- a/src/engine/graphic/GRStaffManager.h
+++ b/src/engine/graphic/GRStaffManager.h
@@ -340,7 +340,7 @@ class GRStaffManager
 		bool	nextTimePosition (int nvoices, bool filltagMode, TCreateStavesState& state);
 		float	systemBreak (int newlineMode, float beginheight);
 		int		initVoices(int cnt);
-        void    applyStaffScale(GRStaff *staff, int staffNum);
+        void    applyStaffSize(GRStaff *staff, int staffNum);
 };
 
 #endif

--- a/src/engine/include/GUIDOEngine.h
+++ b/src/engine/include/GUIDOEngine.h
@@ -670,9 +670,21 @@ units.
 	*/
 	GUIDOAPI(void) 	GuidoGetDefaultPageFormat( GuidoPageFormat* format );
 
-    /** \brief Gives the default score staves format (one staff at a time).
+    /** \brief Gives the staves size scale (one staff at a time).
+        Staff will have given size scale until a \staffFormat tag
+        with "size" param is defined.
+     
+        \param inHandleGR a Guido opaque handle to a GR structure.
+        \param staffNum the staff number on which will be applied new size scale
+        \param sizeScale the size scale between 0 and inifinite. A value of 1 will reset the staff size.
      */
-    GUIDOAPI(void) 	GuidoSetDefaultStaffFormat( CGRHandler inHandleGR, int staffNum, int sizeFactor);
+    GUIDOAPI(void) 	GuidoSetStaffSizeScale( CGRHandler inHandleGR, int staffNum, float sizeScale );
+    
+    /** \brief Get the staff size scale of given staff number.
+     
+        \return the staff size scale, (0 if not defined).
+     */
+    GUIDOAPI(float) 	GuidoGetStaffSizeScale( CGRHandler inHandleGR, int staffNum );
 
 	/** \brief Converts internal Guido units into centimeters.
 

--- a/src/engine/include/GUIDOEngine.h
+++ b/src/engine/include/GUIDOEngine.h
@@ -670,21 +670,23 @@ units.
 	*/
 	GUIDOAPI(void) 	GuidoGetDefaultPageFormat( GuidoPageFormat* format );
 
-    /** \brief Gives the staves size scale (one staff at a time).
-        Staff will have given size scale until a \staffFormat tag
+    /** \brief Gives the staves size (one staff at a time).
+        Staff will have given size until a \staffFormat tag
         with "size" param is defined.
+        Size should be given in internal units. To convert from cm or inches
+        you should use \c GuidoCM2Unit or \c GuidoInches2Unit
      
         \param inHandleGR a Guido opaque handle to a GR structure.
         \param staffNum the staff number on which will be applied new size scale
-        \param sizeScale the size scale between 0 and inifinite. A value of 1 will reset the staff size.
+        \param size the staff size in internal units. A negative value resets the staff size.
      */
-    GUIDOAPI(void) 	GuidoSetStaffSizeScale( CGRHandler inHandleGR, int staffNum, float sizeScale );
+    GUIDOAPI(void) 	GuidoSetStaffSize( CGRHandler inHandleGR, int staffNum, float size );
     
-    /** \brief Get the staff size scale of given staff number.
+    /** \brief Get the staff size of given staff number.
      
-        \return the staff size scale, (0 if not defined).
+        \return the staff size in internal units (-1 if not defined).
      */
-    GUIDOAPI(float) 	GuidoGetStaffSizeScale( CGRHandler inHandleGR, int staffNum );
+    GUIDOAPI(float) 	GuidoGetStaffSize( CGRHandler inHandleGR, int staffNum );
 
 	/** \brief Converts internal Guido units into centimeters.
 

--- a/src/engine/include/GUIDOEngine.h
+++ b/src/engine/include/GUIDOEngine.h
@@ -670,6 +670,10 @@ units.
 	*/
 	GUIDOAPI(void) 	GuidoGetDefaultPageFormat( GuidoPageFormat* format );
 
+    /** \brief Gives the default score staves format (one staff at a time).
+     */
+    GUIDOAPI(void) 	GuidoSetDefaultStaffFormat( CGRHandler inHandleGR, int staffNum, int sizeFactor);
+
 	/** \brief Converts internal Guido units into centimeters.
 
 		\param val the value to be converted

--- a/src/engine/lib/GUIDOEngine.cpp
+++ b/src/engine/lib/GUIDOEngine.cpp
@@ -819,6 +819,17 @@ GUIDOAPI(void) 	GuidoGetPageFormat(	CGRHandler inHandleGR, int pageNum, GuidoPag
 	if( thePage )
 		thePage->getPageFormat( format );
 }
+    
+// --------------------------------------------------------------------------
+GUIDOAPI(void) 	GuidoSetDefaultStaffFormat( CGRHandler inHandleGR, int staffNum, int sizeFactor)
+{
+    if ( inHandleGR == 0 ) return;
+    if ( inHandleGR->grmusic == 0 ) return;
+    if ( staffNum == 0 ) return;
+    if ( sizeFactor == 0 ) return;
+        
+    inHandleGR->grmusic->setStaffScale(staffNum, sizeFactor);
+}
 
 // --------------------------------------------------------------------------
 GUIDOAPI(float) GuidoUnit2CM(float val)

--- a/src/engine/lib/GUIDOEngine.cpp
+++ b/src/engine/lib/GUIDOEngine.cpp
@@ -821,14 +821,24 @@ GUIDOAPI(void) 	GuidoGetPageFormat(	CGRHandler inHandleGR, int pageNum, GuidoPag
 }
     
 // --------------------------------------------------------------------------
-GUIDOAPI(void) 	GuidoSetDefaultStaffFormat( CGRHandler inHandleGR, int staffNum, int sizeFactor)
+GUIDOAPI(void) 	GuidoSetStaffSizeScale( CGRHandler inHandleGR, int staffNum, float sizeFactor )
 {
     if ( inHandleGR == 0 ) return;
     if ( inHandleGR->grmusic == 0 ) return;
     if ( staffNum == 0 ) return;
     if ( sizeFactor == 0 ) return;
         
-    inHandleGR->grmusic->setStaffScale(staffNum, sizeFactor);
+    inHandleGR->grmusic->setStaffSizeScale(staffNum, sizeFactor);
+}
+    
+// --------------------------------------------------------------------------
+GUIDOAPI(float) GuidoGetStaffSizeScale( CGRHandler inHandleGR, int staffNum )
+{
+    if ( inHandleGR == 0 ) return 0;
+    if ( inHandleGR->grmusic == 0 ) return 0;
+    if ( staffNum == 0 ) return 0;
+        
+    return inHandleGR->grmusic->getStaffSizeScale(staffNum);
 }
 
 // --------------------------------------------------------------------------

--- a/src/engine/lib/GUIDOEngine.cpp
+++ b/src/engine/lib/GUIDOEngine.cpp
@@ -821,24 +821,23 @@ GUIDOAPI(void) 	GuidoGetPageFormat(	CGRHandler inHandleGR, int pageNum, GuidoPag
 }
     
 // --------------------------------------------------------------------------
-GUIDOAPI(void) 	GuidoSetStaffSizeScale( CGRHandler inHandleGR, int staffNum, float sizeFactor )
+GUIDOAPI(void) 	GuidoSetStaffSize( CGRHandler inHandleGR, int staffNum, float size )
 {
     if ( inHandleGR == 0 ) return;
     if ( inHandleGR->grmusic == 0 ) return;
-    if ( staffNum == 0 ) return;
-    if ( sizeFactor == 0 ) return;
-        
-    inHandleGR->grmusic->setStaffSizeScale(staffNum, sizeFactor);
+    if ( staffNum <= 0 ) return;
+    
+    inHandleGR->grmusic->setStaffSize(staffNum, size);
 }
     
 // --------------------------------------------------------------------------
-GUIDOAPI(float) GuidoGetStaffSizeScale( CGRHandler inHandleGR, int staffNum )
+GUIDOAPI(float) GuidoGetStaffSize( CGRHandler inHandleGR, int staffNum )
 {
-    if ( inHandleGR == 0 ) return 0;
-    if ( inHandleGR->grmusic == 0 ) return 0;
-    if ( staffNum == 0 ) return 0;
+    if ( inHandleGR == 0 ) return -1;
+    if ( inHandleGR->grmusic == 0 ) return -1;
+    if ( staffNum == 0 ) return -1;
         
-    return inHandleGR->grmusic->getStaffSizeScale(staffNum);
+    return inHandleGR->grmusic->getStaffSize(staffNum);
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
For now, I created `GuidoSetDefaultStaffFormat`, to which we give a `GRHandler`, a staff number and a size scale, and which stores this info in a map in `GRMusic`.
The best is probably to handle this like `GuidoPageFormat` type in API (creating associated type and putting it in `GuidoGrParameters`), but I don't believe we can use std::map in API.