### PR TITLE
Now we can skip a measure number

### DIFF
--- a/gmn-examples/new-tags-v1.64/measureNumberingSkipped.gmn
+++ b/gmn-examples/new-tags-v1.64/measureNumberingSkipped.gmn
@@ -1,0 +1,5 @@
+[
+	\meter<"C", autoMeasuresNum="on">
+	(* System 1 *) a b c d a b c d
+	(* System 2 *) \bar<displayMeasNum="skipped"> a | a b c d a b c d
+]

--- a/src/engine/abstract/ARBar.cpp
+++ b/src/engine/abstract/ARBar.cpp
@@ -31,6 +31,7 @@ ARBar::ARBar(const TYPE_TIMEPOSITION &timeposition)
 	measureNumber               = 0;
     measureNumberDisplayed      = false;
     measureNumberDisplayedIsSet = false;
+    fSkippedMeasureNum          = false;
 
 	numDx = 0;
 	numDy = 0;
@@ -41,7 +42,8 @@ ARBar::ARBar() : ARMTParameter()
 	measureNumber               = 0;
     measureNumberDisplayed      = kNoNum;
     measureNumberDisplayedIsSet = false;
-
+    fSkippedMeasureNum          = false;
+    
 	numDx = 0;
 	numDy = 0;
 }
@@ -75,11 +77,14 @@ void ARBar::setTagParameterList(TagParameterList& tpl)
 			// w, h, ml, mt, mr, mb
 
             TagParameterString *s = TagParameterString::cast(rtpl->RemoveHead());
-			bool display =  s->getBool();
             if (s->TagIsSet()) {
-				measureNumberDisplayed = display ? kNumAll : kNoNum;
+                std::string skipped("skipped");
+                const char* displayMeasNum = s->getValue();
+                
+                fSkippedMeasureNum = (skipped == displayMeasNum);
+                measureNumberDisplayed = (s->getBool() ? kNumAll : kNoNum);
                 measureNumberDisplayedIsSet = true;
-			}
+            }
             delete s;
 
 			// - dx/dy for measure number
@@ -116,6 +121,7 @@ void ARBar::printParameters(std::ostream& os) const
 {
     os << "measureNumber: " << measureNumber << "; ";
     os << "measureNumberDisplayed: " << measureNumberDisplayed << "; ";
+    os << "skipped: " << fSkippedMeasureNum << "; ";
     os << "numDx: " << numDx << "; ";
     os << "numDy: " << numDy << ";";
 

--- a/src/engine/abstract/ARBar.h
+++ b/src/engine/abstract/ARBar.h
@@ -43,6 +43,8 @@ class ARBar : // public ARMusicalObject,
         void  setMeasureNumberDisplayed(int mode)	  { measureNumberDisplayed = mode; }
         bool  isMeasureNumberDisplayedSet() const     { return measureNumberDisplayedIsSet; }
 
+        bool isMeasureNumSkipped() const                       { return fSkippedMeasureNum; }
+     
 		float getMeasureNumberDxOffset() const        { return numDx; }
 		float getMeasureNumberDyOffset() const        { return numDy; }
 		
@@ -60,6 +62,7 @@ class ARBar : // public ARMusicalObject,
 
 		int   measureNumber;
         int   measureNumberDisplayed;
+        bool  fSkippedMeasureNum;
 		float numDx;
 		float numDy;
 		const ARBar*	fLastBar;

--- a/src/engine/abstract/ARMusicalVoice.cpp
+++ b/src/engine/abstract/ARMusicalVoice.cpp
@@ -2386,6 +2386,8 @@ void ARMusicalVoice::doAutoMeasuresNumbering()
 
 		if (bar)
 		{
+            if (bar->isMeasureNumSkipped())
+                measureNumber--;
 			bar->setMeasureNumber(measureNumber);
 			bar->setPreviousBar (previous);
 
@@ -2412,6 +2414,7 @@ void ARMusicalVoice::doAutoMeasuresNumbering()
                         bar->setMeasureNumberDisplayed(ARBar::kNumSystem);
                 }
             }
+            
             measureNumber++;
 			previous = bar;
 		}


### PR DESCRIPTION
‘skipped’ value has been added to ‘displayMeasNum’ param, in ‘bar’ tag, to skip the numbering of current bar (skip = hide + no increment).

This is an solution to the second point of [issue 21](https://github.com/grame-cncm/guidolib/issues/21).

No changes in validation.