### PR TITLE
Use GitHub Actions to build docker image on each push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    # Display name for the GHA page
+    name: Linux docker
+
+    runs-on: ubuntu-18.04
+
+    # Is 10 mins enough?
+    timeout-minutes: 10
+
+    steps:
+    - name: Repo checkout
+      uses: actions/checkout@v2
+
+    - name: build
+      run: |
+        cd build/docker/
+        make all
+        make run 

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ src/tools/*.svg
 tmpSrc
 validate/*.exe
 validate/GUIDOEngine.dll
+
+# IntelliJ project files
+.idea/

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
 Welcome to the Guido project
+![CI](https://github.com/olafure/guidolib/workflows/CI/badge.svg)
+
 ======================================================================
 
 [Grame](http://www.grame.fr) - Centre National de Création Musicale
@@ -16,6 +18,7 @@ See [Guido wiki](https://github.com/grame-cncm/guidolib/wiki) for building instr
 ---
 
 Travis build status:  <a href="https://travis-ci.org/grame-cncm/guidolib"><img src="https://travis-ci.org/grame-cncm/guidolib.svg?branch=dev"></a>
+GitHub Actions docker build: ![CI](https://github.com/olafure/guidolib/workflows/CI/badge.svg?branch=ci-with-gh-actions)
 
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
The docker build is failing at the moment.  This PR doesn't fix it, but it does add a GitHub Action CI workflow, so it gets built on every push.
