### PR TITLE
Updated juce environment

### DIFF
--- a/environments/juce/Device/JuceDevice.cpp
+++ b/environments/juce/Device/JuceDevice.cpp
@@ -289,7 +289,7 @@ void JuceDevice::DrawString( float x, float y, const char * s, int inCharCount )
 	else if (fFontAlign & kAlignRight)
 		x -= w;
 
-	String text (s, inCharCount);
+	auto text = String::fromUTF8 (s, inCharCount);
 	fGraphics->setColour (Color2JColor(fFontColor));
 	fGraphics->drawSingleLineText (text, int(x), int(y));
 	fGraphics->setColour (Color2JColor(fFillColor));

--- a/environments/juce/Device/JuceFont.cpp
+++ b/environments/juce/Device/JuceFont.cpp
@@ -54,7 +54,7 @@ int JuceFont::GetProperties() const
 // - Symbol services ---------------------------------------------
 void JuceFont::GetExtent( const char * s, int count, float * width, float * height, VGDevice *) const
 {
-	String text (s, count);
+	auto text = String::fromUTF8 (s, count);
 	*width = fNativeFont->getStringWidthFloat (text);
 	*height = fNativeFont->getAscent() + fNativeFont->getDescent();
 }

--- a/environments/juce/GuidoViewer/GuidoViewer.jucer
+++ b/environments/juce/GuidoViewer/GuidoViewer.jucer
@@ -8,18 +8,22 @@
               pluginSilenceInIsSilenceOut="0" pluginTailLength="0" pluginEditorRequiresKeys="0"
               pluginAUExportPrefix="JuceProjectAU" pluginAUViewClass="JuceProjectAU_V1"
               pluginRTASCategory="" bundleIdentifier="com.grame.GuidoViewer"
-              jucerVersion="5.3.2" defines="JUCE_DONT_DEFINE_MACROS" includeBinaryInAppConfig="1"
-              pluginFormats="buildVST,buildAU" headerPath="../../../../../src/engine/include&#10;../../../Device">
+              defines="JUCE_DONT_DEFINE_MACROS&#10;JUCE_MODAL_LOOPS_PERMITTED=1"
+              includeBinaryInAppConfig="1" pluginFormats="buildVST,buildAU"
+              headerPath="../../../../../src/engine/include&#10;../../../Device"
+              jucerFormatVersion="1">
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" vstFolder="~/SDKs/vstsdk2.4" rtasFolder="~/SDKs/PT_80_SDK"
-               objCExtraSuffix="WzPHFY" extraLinkerFlags="-F../../../../../build/lib  -framework GUIDOEngine&#10;"
-               bigIcon="IAUjPh">
+               objCExtraSuffix="WzPHFY" extraLinkerFlags="-F${PROJECT_DIR}/../../../../../build/lib  -framework GUIDOEngine&#10;"
+               bigIcon="IAUjPh" useLegacyBuildSystem="1">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="GuidoViewer"
-                       osxCompatibility="10.6 SDK" libraryPath="/Users/fober/src/guido/guidolib/build/lib"/>
+                       osxCompatibility="10.12 SDK" libraryPath="${PROJECT_DIR}/../../../../../build/lib"
+                       macOSDeploymentTarget="10.12"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="2" targetName="GuidoViewer"
-                       osxCompatibility="10.6 SDK" osxArchitecture="64BitUniversal"
-                       binaryPath="" libraryPath="/Users/fober/src/guido/guidolib/build/lib"/>
+                       osxCompatibility="10.12 SDK" osxArchitecture="64BitUniversal"
+                       binaryPath="" libraryPath="${PROJECT_DIR}/../../../../../build/lib"
+                       macOSDeploymentTarget="10.12"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_basics" path="../../../../../../juce/modules"/>
@@ -34,10 +38,10 @@
                   extraCompilerFlags="-I../../../../src/include" bigIcon="IAUjPh">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="GuidoViewer"
-                       osxCompatibility="10.6 SDK" osxArchitecture="Native"/>
+                       osxCompatibility="10.12 SDK" osxArchitecture="Native" macOSDeploymentTarget="10.12"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="2" targetName="GuidoViewer"
-                       osxCompatibility="10.6 SDK" osxArchitecture="64BitUniversal"
-                       binaryPath=""/>
+                       osxCompatibility="10.12 SDK" osxArchitecture="64BitUniversal"
+                       binaryPath="" macOSDeploymentTarget="10.12"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_basics" path="../../../../../../juce/modules"/>

--- a/environments/juce/GuidoViewer/Source/Main.cpp
+++ b/environments/juce/GuidoViewer/Source/Main.cpp
@@ -30,13 +30,13 @@ public:
     void initialise (const String& )
     {
         // Do your application's initialisation code here..
-        mainWindow = new MainAppWindow();
+        mainWindow = std::make_unique<MainAppWindow>();
     }
 
     void shutdown()
     {
         // Do your application's shutdown code here..
-        mainWindow = 0;
+        mainWindow.reset();
     }
 
     //==============================================================================
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-    ScopedPointer <MainAppWindow> mainWindow;
+    std::unique_ptr<MainAppWindow> mainWindow;
 };
 
 //==============================================================================


### PR DESCRIPTION
This PR updates the juce environment and example to build against JUCE 6 & 7.

The JuceDevice and JuceFont used a generic String constructor, so any GNM file with non ASCII characters would assert. E.g. the examples beethoven.gnm and faure.gnm having utf-8 characters. This is now changed to assume utf-8.

No license restrictions are tied to this PR, everybody is free to use the changes at their own discretion (CLA).