### PR TITLE
Bugfix/issue 196 part2

### DIFF
--- a/open-issues/g-issue196-2.gmn
+++ b/open-issues/g-issue196-2.gmn
@@ -1,40 +1,31 @@
-{[ \staff<1> \title<"Moonlight Sonata"> \composer<"Ludwig van Beethoven", dy=4hs> 
-   (* meas. 1 *)  \clef<"g2"> \key<4> \meter<"C/", autoBarlines="off", autoMeasuresNum="system"> \stemsUp \beamsOff \acc( g1/2)
+{[ \staff<1> \title<"Moonlight Sonata">  
+   (* meas. 1 *)  \clef<"g2"> \key<4> \meter<"C/"> \stemsUp \beamsOff \acc( g1/2)
  \beamsOff f#1/2 \bar<measNum=2> 
    (* meas. 2 *)  \clef<"f4"> \beamsOff c#1/2 \beamsOff c#1/4 \beamsOff c#1/4 \bar<measNum=3> 
    (* meas. 3 *)  \crescBegin<dy=-10.4hs> \beamsOff f#0/4 \restFormat<dy=-9>( _/4)
  \clef<"g2"> \restFormat<dy=-6>( _/4)
  \intens<"p", dy=-10.6hs, dx=0> \beamBegin:1 c#2/8. \crescEnd c#2/16 \beamEnd:1 \staff<1> \endBar ]
  , 
-[ \staff<1> \set<autoHideTiedAccidentals="on"> \barFormat<style= "system", range="1"> \clef<"g2"> 
-   (* meas. 1 *)  \stemsDown \beamBegin:1 \tuplet<"", dispNote="/8">( \acc( g0/12)
- b0/12 \fingering<dy=-12.2hs, dx=-0.8, text="3">( \acc( d1/12)
-)
-)
+[ \staff<1> \clef<"g2"> 
+   (* meas. 1 *)  \stemsDown \beamBegin:1 
+   \tuplet<"", dispNote="/8">( \acc( g0/12) b0/12 \fingering<dy=-12.2hs, dx=-0.8, text="3">( \acc( d1/12)))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( g0/12 b0/12 d1/12)
- \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( f#0/12 a0/12 \fingering<dy=-13.2hs, dx=-1, text="4">( \acc( d#1/12)
-)
-)
+ \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( f#0/12 a0/12 \fingering<dy=-13.2hs, dx=-1, text="4">( \acc( d#1/12)))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( f#0/12 a0/12 d#1/12)
  \beamEnd:1 \bar<measNum=2> 
-   (* meas. 2 *)  \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-11.2hs, dx=-0.8, text="4">( a0/12)
-)
+   (* meas. 2 *)  
+ \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-11.2hs, dx=-0.8, text="4">( a0/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 a0/12)
- \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-10.2hs, dx=-0.8, text="3">( g#0/12)
-)
- \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 \acc( e#0/12)
- g#0/12)
+ \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-10.2hs, dx=-0.8, text="3">( g#0/12))
+ \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 \acc( e#0/12) g#0/12)
  \beamEnd:1 \bar<measNum=3> 
    (* meas. 3 *)  \beamBegin:1 \tuplet<"", dispNote="/8">( \fingering<dy=-7.4hs, dx=-0.8, text="2">( f#0/12)
  \fingering<dy=-9.4hs, dx=-1, text="3">( a0/12)
- \fingering<dy=-11.4hs, dx=-0.8, text="5">( c#1/12)
-)
+ \fingering<dy=-11.4hs, dx=-0.8, text="5">( c#1/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( \fingering<dy=-9.4hs, dx=-0.8, text="1">( a0/12)
- c#1/12 \fingering<dy=-14.4hs, dx=-0.8, text="4">( f#1/12)
-)
+ c#1/12 \fingering<dy=-14.4hs, dx=-0.8, text="4">( f#1/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( \fingering<dy=-9.2hs, dx=-0.8, text="1">( c#1/12)
- f#1/12 \fingering<dy=-13.2hs, dx=-0.8, text="3">( a1/12)
-)
+ f#1/12 \fingering<dy=-13.2hs, dx=-0.8, text="3">( a1/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#1/12 f#1/12 a1/12)
  \beamEnd:1 \staff<1> \endBar ]
   }

--- a/open-issues/g-issue196-2.gmn
+++ b/open-issues/g-issue196-2.gmn
@@ -14,7 +14,8 @@
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( f#0/12 a0/12 d#1/12)
  \beamEnd:1 \bar<measNum=2> 
    (* meas. 2 *)  
- \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-11.2hs, dx=-0.8, text="4">( a0/12))
+ \beamBegin:1 
+ \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-11.2hs, dx=-0.8, text="4">( a0/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 a0/12)
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 f#0/12 \fingering<dy=-10.2hs, dx=-0.8, text="3">( g#0/12))
  \beamEnd:1 \beamBegin:1 \tuplet<"", dispNote="/8">( c#0/12 \acc( e#0/12) g#0/12)

--- a/open-issues/g-issue196-3.gmn
+++ b/open-issues/g-issue196-3.gmn
@@ -1,0 +1,64 @@
+{[ \staff<1> \set<autoHideTiedAccidentals="on"> \title<"The Art of Finger Dexterity Op.740 - No.27 Allegro"> \composer<"Compositeur", dy=4hs> \auto<autoInstrPos="on"> \instr<"Piano"> \accol<id=0, range="1-2"> \barFormat<style= "system", range="1-2"> 
+   (* meas. 1 *)  \clef<"g2"> \key<2> \meter<"3/4", autoBarlines="off", autoMeasuresNum="system"> _*3/4 \bar<measNum=2> 
+   (* meas. 2 *)  _*3/4 \bar<measNum=3> 
+   (* meas. 3 *)  _*3/4 \bar<measNum=4> 
+   (* meas. 4 *)  _*3/4 \bar<measNum=5> 
+   (* meas. 5 *)  _*3/4 \bar<measNum=6> 
+   (* meas. 6 *)  _*3/4 \bar<measNum=7> 
+   (* meas. 7 *)  _/2. \bar<measNum=8> 
+   (* meas. 8 *)  _/2. \bar<measNum=9> 
+   (* meas. 9 *)  _/2. \bar<measNum=10> 
+   (* meas. 10 *)  _/2. \staff<1> \endBar ]
+ , 
+[ \staff<2> \set<autoHideTiedAccidentals="on"> \barFormat<style= "system", range="2"> 
+   (* meas. 1 *)  \staffFormat<distance=15> \clef<"f4"> \key<2> \meter<"3/4"> 
+   \restFormat<dy=-6>( _/4)
+ \stemsUp \beamsOff {a0/2, \acc( c#1/2)} \bar<measNum=2> 
+   (* meas. 2 *)  \slurBegin:1<curve="up"> \beamsOff {d-1/4, a-1/4, d0/4  } \restFormat<dy=-6>( _/4)
+ \beamsOff {b&-1/4, d0/4, \acc( g#0/4)
+  } \slurEnd:1 \bar<measNum=3> 
+   (* meas. 3 *)  \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="up"> \beamsOff {e1/4, c#2/4  } \beamsOff {c#1/4, e1/4, a1/4  } \slurEnd:1 \bar<measNum=4> 
+   (* meas. 4 *)  \clef<"f4"> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {a0/4, d1/4, f#1/4  } \beamsOff {b0/4, d1/4, \acc( g#1/4)
+  } \slurEnd:1 \bar<measNum=5> 
+   (* meas. 5 *)  \clef<"f4"> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \beamsOff {e1/4, c#2/4  } \beamsOff {c#1/4, e1/4, a1/4  } \bar<measNum=6> 
+   (* meas. 6 *)  \clef<"f4"> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {a0/4, d1/4, f#1/4  } \beamsOff {b0/4, d1/4, \acc( g#1/4)
+  } \slurEnd:1 \bar<measNum=7> 
+   (* meas. 7 *)  \staffFormat<distance=15> \clef<"f4"> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {c#1/4, a1/4  } \beamsOff {e1/4, a1/4, c#2/4  } \slurEnd:1 \bar<measNum=8> 
+   (* meas. 8 *)  \clef<"f4"> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {d1/4, a1/4, b1/4  } \beamsOff {f#1/4, a1/4, d2/4  } \slurEnd:1 \clef<"f4"> \bar<measNum=9> 
+   (* meas. 9 *)  \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {e1/4, a1/4, c#2/4  } \beamsOff {g1/4, a1/4, e2/4  } \slurEnd:1 \clef<"f4"> \bar<measNum=10> 
+   (* meas. 10 *)  \intens<"sf", dy=20hs, dx=0> \restFormat<dy=-6>( _/4)
+ \clef<"g2"> \slurBegin:1<curve="down"> \beamsOff {f#1/4, a1/4, d2/4  } \beamsOff {a1/4, d2/4, f#2/4  } \slurEnd:1 \clef<"f4"> \staff<2> \endBar ]
+ , 
+[ \staff<2> \set<autoHideTiedAccidentals="on"> \barFormat<style= "system", range="2"> 
+   (* meas. 1 *)  \staffFormat<distance=15> empty/4 \stemsDown \slurBegin:1<curve="down"> 
+   \beamsOff \noteFormat<dx=2>( g0/4)
+ \beamsOff e0/4 \slurEnd:1 \bar<measNum=2> 
+   (* meas. 2 *)  empty/4 \beamsOff {\acc( b&-2/2), \acc( b&-1/2)} \bar<measNum=3> 
+   (* meas. 3 *)  \beamsOff {a-2/2., a-1/2.  } \bar<measNum=4> 
+   (* meas. 4 *)  \beamsOff {e-2/2., e-1/2.  } \bar<measNum=5> 
+   (* meas. 5 *)  \beamsOff {a-2/2., a-1/2.  } \bar<measNum=6> 
+   (* meas. 6 *)  \beamsOff {e-2/2., e-1/2.  } \bar<measNum=7> 
+   (* meas. 7 *)  \staffFormat<distance=15> \beamsOff {a-2/2., a-1/2.  } \bar<measNum=8> 
+   (* meas. 8 *)  \beamsOff {a-2/2., a-1/2.  } \bar<measNum=9> 
+   (* meas. 9 *)  \beamsOff {a-2/2., a-1/2.  } \bar<measNum=10> 
+   (* meas. 10 *)  \beamsOff {a-2/2., a-1/2.  } \staff<2> \endBar ]
+ , 
+[ \staff<2> \set<autoHideTiedAccidentals="on"> \barFormat<style= "system", range="2"> 
+   (* meas. 1 *)  \staffFormat<distance=15> \stemsDown \beamsOff {a-2/2., a-1/2.  } \bar<measNum=2> 
+   (* meas. 2 *)  empty*3/4 \bar<measNum=3> 
+   (* meas. 3 *)  empty/4 empty/2 \bar<measNum=4> 
+   (* meas. 4 *)  empty/4 empty/2 \bar<measNum=5> 
+   (* meas. 5 *)  empty/4 empty/2 \bar<measNum=6> 
+   (* meas. 6 *)  empty/4 empty/2 \bar<measNum=7> 
+   (* meas. 7 *)  \staffFormat<distance=15> empty/4 empty/2 \bar<measNum=8> 
+   (* meas. 8 *)  empty/4 empty/2 \bar<measNum=9> 
+   (* meas. 9 *)  empty/4 empty/2 \bar<measNum=10> 
+   (* meas. 10 *)  empty/4 empty/2 \staff<2> \endBar ]
+  }

--- a/src/engine/graphic/GRStaff.cpp
+++ b/src/engine/graphic/GRStaff.cpp
@@ -200,6 +200,8 @@ GRStaffState::GRStaffState()
 	initBaseLine = baseline;
 	initBaseOct = baseoct;
 	initClefCaptured = false;
+	clefTimeSet = false;
+	clefTime = DURATION_0;
 
 	distanceset = false;
 	distance    = 0;
@@ -254,6 +256,8 @@ GRStaffState & GRStaffState::operator=(const GRStaffState & state)
 	octava		= state.octava;
 	baseline	= state.baseline;
 	curclef		= state.curclef;
+	clefTimeSet = state.clefTimeSet;
+	clefTime	= state.clefTime;
 
 	curstaffrmt = state.curstaffrmt;
 	staffLSPACE = LSPACE;
@@ -741,6 +745,8 @@ void GRStaff::setMeterParameters(GRMeter * grmeter)
 void GRStaff::setClefParameters(GRClef * grclef, GRStaffState::clefstate cstate)
 {
 	mStaffState.clefset = cstate;
+	mStaffState.clefTimeSet = (grclef != NULL);
+	mStaffState.clefTime = grclef ? grclef->getRelativeTimePosition() : DURATION_0;
 	if (grclef == NULL)
 	{ // Standard ...
 		mStaffState.curclef = NULL;

--- a/src/engine/graphic/GRStaff.cpp
+++ b/src/engine/graphic/GRStaff.cpp
@@ -196,6 +196,10 @@ GRStaffState::GRStaffState()
 	octava       = 0;
 	baseline     = 3;
 	curclef      = NULL;
+	initBasePit = basepit;
+	initBaseLine = baseline;
+	initBaseOct = baseoct;
+	initClefCaptured = false;
 
 	distanceset = false;
 	distance    = 0;
@@ -757,6 +761,16 @@ void GRStaff::setClefParameters(GRClef * grclef, GRStaffState::clefstate cstate)
 		mStaffState.baseoct = grclef->getBaseOct();
 		mStaffState.octava = 0;
 		mStaffState.baseline = grclef->getBaseLine();
+	}
+
+	// Remember the first explicit clef encountered on this staff so that voices
+	// without their own clef keep using the initial baseline even if another
+	// voice changes the staff clef later.
+	if (!mStaffState.initClefCaptured) {
+		mStaffState.initBasePit = mStaffState.basepit;
+		mStaffState.initBaseLine = mStaffState.baseline;
+		mStaffState.initBaseOct = mStaffState.baseoct;
+		mStaffState.initClefCaptured = true;
 	}
 
 	// now we have to take into consideration the 

--- a/src/engine/graphic/GRStaff.cpp
+++ b/src/engine/graphic/GRStaff.cpp
@@ -202,6 +202,7 @@ GRStaffState::GRStaffState()
 	initClefCaptured = false;
 	clefTimeSet = false;
 	clefTime = DURATION_0;
+	clefHistory.clear();
 
 	distanceset = false;
 	distance    = 0;
@@ -258,6 +259,7 @@ GRStaffState & GRStaffState::operator=(const GRStaffState & state)
 	curclef		= state.curclef;
 	clefTimeSet = state.clefTimeSet;
 	clefTime	= state.clefTime;
+	clefHistory = state.clefHistory;
 
 	curstaffrmt = state.curstaffrmt;
 	staffLSPACE = LSPACE;
@@ -778,11 +780,38 @@ void GRStaff::setClefParameters(GRClef * grclef, GRStaffState::clefstate cstate)
 		mStaffState.initBaseOct = mStaffState.baseoct;
 		mStaffState.initClefCaptured = true;
 	}
+	if (mStaffState.clefTimeSet)
+		mStaffState.rememberClef(mStaffState.clefTime, mStaffState.basepit, mStaffState.baseline, mStaffState.baseoct);
 
 	// now we have to take into consideration the 
 	// instrument-offset (e.g. "clarinet in A")
 	// which changes the basepitch ....
 	// (relative to the "normal" C-Major oriented scale)
+}
+
+bool GRStaffState::getClefAtTime(const TYPE_TIMEPOSITION& tp, int& basePitch, int& baseLine, int& baseOct, TYPE_TIMEPOSITION& clefAtTime) const
+{
+	bool found = false;
+	TYPE_TIMEPOSITION latest = DURATION_0;
+	for (const auto& entry : clefHistory) {
+		if (entry.time <= tp) {
+			if (!found || entry.time >= latest) {
+				found = true;
+				latest = entry.time;
+				basePitch = entry.basePitch;
+				baseLine = entry.baseLine;
+				baseOct = entry.baseOct;
+			}
+		}
+	}
+	if (found)
+		clefAtTime = latest;
+	return found;
+}
+
+void GRStaffState::rememberClef(const TYPE_TIMEPOSITION& tp, int basePitch, int baseLine, int baseOct)
+{
+	clefHistory.push_back({tp, basePitch, baseLine, baseOct});
 }
 
 // ----------------------------------------------------------------------------
@@ -1569,6 +1598,7 @@ staff_debug("CreateBeginElements");
 	mStaffState.basepitoffs = state.basepitoffs;
 	mStaffState.instrNumKeys = state.instrNumKeys;
 	mStaffState.fInstrument = state.fInstrument;
+    mStaffState.clefHistory = state.clefHistory;
 	
 	// we have to look, what kind of state-settings are set.
 	if (state.curbarfrmt != NULL)
@@ -1918,6 +1948,7 @@ staff_debug("setStaffState");
 
 	mStaffState.distanceset = state->distanceset;
 	mStaffState.distance = state->distance;
+    mStaffState.clefHistory = state->clefHistory;
 // DebugPrintState( "setStaffState apres" );
 
 }

--- a/src/engine/graphic/GRStaff.h
+++ b/src/engine/graphic/GRStaff.h
@@ -118,6 +118,8 @@ class GRStaffState
 		int				getInitialBaseLine() const				{ return initBaseLine; }
 		int				getInitialBaseOctave() const			{ return initBaseOct; }
 		bool			hasInitialClef() const					{ return initClefCaptured; }
+		bool			hasClefTime() const						{ return clefTimeSet; }
+		TYPE_TIMEPOSITION getClefTime() const					{ return clefTime; }
 
 		GRStaffState & operator=(const GRStaffState &tmp);
 
@@ -163,6 +165,8 @@ class GRStaffState
 		int initBaseLine;
 		int initBaseOct;
 		bool initClefCaptured;
+		bool clefTimeSet;
+		TYPE_TIMEPOSITION clefTime;
 		float instrKeyArray[NUMNOTES];
 				// the key-array for the current instrument (if transposed).
 

--- a/src/engine/graphic/GRStaff.h
+++ b/src/engine/graphic/GRStaff.h
@@ -16,6 +16,7 @@
 */
 
 #include <iostream>
+#include <vector>
 
 #include "GRCompositeNotationElement.h"
 #include "GuidoDefs.h"
@@ -120,6 +121,8 @@ class GRStaffState
 		bool			hasInitialClef() const					{ return initClefCaptured; }
 		bool			hasClefTime() const						{ return clefTimeSet; }
 		TYPE_TIMEPOSITION getClefTime() const					{ return clefTime; }
+		bool			getClefAtTime(const TYPE_TIMEPOSITION& tp, int& basePitch, int& baseLine, int& baseOct, TYPE_TIMEPOSITION& clefAtTime) const;
+		void			rememberClef(const TYPE_TIMEPOSITION& tp, int basePitch, int baseLine, int baseOct);
 
 		GRStaffState & operator=(const GRStaffState &tmp);
 
@@ -167,6 +170,13 @@ class GRStaffState
 		bool initClefCaptured;
 		bool clefTimeSet;
 		TYPE_TIMEPOSITION clefTime;
+		struct ClefEntry {
+			TYPE_TIMEPOSITION time;
+			int basePitch;
+			int baseLine;
+			int baseOct;
+		};
+		std::vector<ClefEntry> clefHistory;
 		float instrKeyArray[NUMNOTES];
 				// the key-array for the current instrument (if transposed).
 

--- a/src/engine/graphic/GRStaff.h
+++ b/src/engine/graphic/GRStaff.h
@@ -114,6 +114,10 @@ class GRStaffState
 		int				getBaseLine() const						{ return baseline; }
 		int				getBaseOctave() const					{ return baseoct; }
 		int				getBasePitchOffset() const				{ return basepitoffs; }
+		int				getInitialBasePitch() const				{ return initBasePit; }
+		int				getInitialBaseLine() const				{ return initBaseLine; }
+		int				getInitialBaseOctave() const			{ return initBaseOct; }
+		bool			hasInitialClef() const					{ return initClefCaptured; }
 
 		GRStaffState & operator=(const GRStaffState &tmp);
 
@@ -152,6 +156,13 @@ class GRStaffState
 				// basepitoffs: the offset for the given instrument, example: clarinet in A
 				// has an offset of -2, it is two pitchclasses away from c-major
 				// instrnumkeys: the number of keys for the transposed instrument ,,,
+
+		// First explicit clef seen on the staff. Voices without a clef of their own
+		// should keep referring to this even if another voice changes the staff clef later.
+		int initBasePit;
+		int initBaseLine;
+		int initBaseOct;
+		bool initClefCaptured;
 		float instrKeyArray[NUMNOTES];
 				// the key-array for the current instrument (if transposed).
 

--- a/src/engine/graphic/GRVoiceManager.cpp
+++ b/src/engine/graphic/GRVoiceManager.cpp
@@ -1954,29 +1954,36 @@ GRSingleNote * GRVoiceManager::CreateSingleNote( const TYPE_TIMEPOSITION & tp, A
 	TYPE_DURATION dtempl = findDuration (fVoiceState, curev);
 
 	// we need to take care of dots !
-    const ARNote * tmpNote = static_cast<const ARNote *>(curev->isARNote());
+	const ARNote * tmpNote = static_cast<const ARNote *>(curev->isARNote());
 	dtempl.normalize();
 
 	GRSingleNote * grnote = new GRSingleNote(mCurGrStaff, tmpNote, tp, arObject->getDuration());
+	const GRStaffState& staffState = mCurGrStaff->getGRStaffState();
+	int basePitch = staffState.getBasePitch();
+	int baseLine = staffState.getBaseLine();
+	int baseOct = staffState.getBaseOctave();
+
 	if (mHasVoiceClefTag) {
 		// Only override the staff clef when this voice has explicitly set one.
 		if (ARMusicalTag * clefTag = fVoiceState->getCurStateTag(typeid(ARClef))) {
 			if (const ARClef * voiceClef = dynamic_cast<const ARClef *>(clefTag)) {
 				if (!voiceClef->getIsAuto()) {
-					const GRStaffState& staffState = mCurGrStaff->getGRStaffState();
 					GRClef tmpClef(voiceClef, mCurGrStaff);
-					const int basePitch = tmpClef.getBasePitch() + staffState.getBasePitchOffset();
-					const int baseLine = tmpClef.getBaseLine();
-					const int baseOct = tmpClef.getBaseOct();
-					if (basePitch != staffState.getBasePitch()
-						|| baseLine != staffState.getBaseLine()
-						|| baseOct != staffState.getBaseOctave()) {
-						grnote->setClefReference(basePitch, baseLine, baseOct);
-					}
+					basePitch = tmpClef.getBasePitch() + staffState.getBasePitchOffset();
+					baseLine = tmpClef.getBaseLine();
+					baseOct = tmpClef.getBaseOct();
 				}
 			}
 		}
 	}
+	// Voice without its own clef: keep using the staff's initial clef so later
+	// clef changes in other voices don't shift this voice's pitches.
+	else if (staffState.hasInitialClef()) {
+		basePitch = staffState.getInitialBasePitch();
+		baseLine = staffState.getInitialBaseLine();
+		baseOct = staffState.getInitialBaseOctave();
+	}
+	grnote->setClefReference(basePitch, baseLine, baseOct);
     grnote->setGraceNote(isGrace);
 	if (size)						grnote->setSize(size);
 	if (curglobalstem)				grnote->setGlobalStem(curglobalstem);

--- a/src/engine/graphic/GRVoiceManager.cpp
+++ b/src/engine/graphic/GRVoiceManager.cpp
@@ -202,6 +202,7 @@ GRVoiceManager::GRVoiceManager(GRMusic* music, GRStaffManager * p_staffmgr, cons
 	grvoice = fMusic->getVoice(arVoice);
 	mVoiceClefTime = DURATION_0;
 	mVoiceClefTimeSet = false;
+	mHasExplicitVoiceClef = false;
 
 	fLastOctava = NULL;
 	fGRTags = NULL;
@@ -287,6 +288,7 @@ bool GRVoiceManager::parseStateTag(const ARMusicalTag * mtag)
 		// until this voice sets a new one.
 		fVoiceState->RemoveCurStateTag(typeid(ARClef));
 		mHasVoiceClefTag = false;
+		mHasExplicitVoiceClef = false;
 		mVoiceClefTimeSet = false;
 		mVoiceClefTime = DURATION_0;
 	}
@@ -934,8 +936,11 @@ GRNotationElement * GRVoiceManager::parseTag(ARMusicalObject * arOfCompleteObjec
 	}
 	else if (tinf == typeid(ARClef)) 
 	{
-		grne = mCurGrStaff->AddClef(static_cast<const ARClef *>(arOfCompleteObject));
+		const ARClef* arclef = static_cast<const ARClef *>(arOfCompleteObject);
+		grne = mCurGrStaff->AddClef(arclef);
 		mHasVoiceClefTag = true;
+		if (!arclef->getIsAuto())
+			mHasExplicitVoiceClef = true;
 		mVoiceClefTime = arOfCompleteObject->getRelativeTimePosition();
 		mVoiceClefTimeSet = true;
 		
@@ -1969,6 +1974,11 @@ GRSingleNote * GRVoiceManager::CreateSingleNote( const TYPE_TIMEPOSITION & tp, A
 	int basePitch = staffState.getBasePitch();
 	int baseLine = staffState.getBaseLine();
 	int baseOct = staffState.getBaseOctave();
+	int staffClefPitch = basePitch;
+	int staffClefLine = baseLine;
+	int staffClefOct = baseOct;
+	TYPE_TIMEPOSITION staffClefTime = DURATION_0;
+	const bool hasStaffClefAtNote = staffState.getClefAtTime(noteStart, staffClefPitch, staffClefLine, staffClefOct, staffClefTime);
 
 	const ARClef* voiceClef = nullptr;
 	TYPE_TIMEPOSITION voiceClefTime = mVoiceClefTime;
@@ -1979,23 +1989,25 @@ GRSingleNote * GRVoiceManager::CreateSingleNote( const TYPE_TIMEPOSITION & tp, A
 		}
 	}
 
-	bool useVoiceClef = mHasVoiceClefTag && voiceClef;
-	if (useVoiceClef && staffState.hasClefTime()) {
-		const TYPE_TIMEPOSITION& staffClefTime = staffState.getClefTime();
-		if ((staffClefTime >= voiceClefTime) && (staffClefTime <= noteStart)) {
+	bool useVoiceClef = mHasExplicitVoiceClef && voiceClef && !voiceClef->getIsAuto();
+	if (useVoiceClef && hasStaffClefAtNote) {
+		if (staffClefTime >= voiceClefTime) {
 			useVoiceClef = false;
 		}
 	}
 
-	if (useVoiceClef && voiceClef && !voiceClef->getIsAuto()) {
+	if (useVoiceClef) {
 		GRClef tmpClef(voiceClef, mCurGrStaff);
 		basePitch = tmpClef.getBasePitch() + staffState.getBasePitchOffset();
 		baseLine = tmpClef.getBaseLine();
 		baseOct = tmpClef.getBaseOct();
 	}
-	// Voice without its own clef: keep using the staff's initial clef so later
-	// clef changes in other voices don't shift this voice's pitches.
-	else if (!mHasVoiceClefTag && staffState.hasInitialClef()) {
+	else if (hasStaffClefAtNote) {
+		basePitch = staffClefPitch;
+		baseLine = staffClefLine;
+		baseOct = staffClefOct;
+	}
+	else if (staffState.hasInitialClef()) {
 		basePitch = staffState.getInitialBasePitch();
 		baseLine = staffState.getInitialBaseLine();
 		baseOct = staffState.getInitialBaseOctave();

--- a/src/engine/graphic/GRVoiceManager.cpp
+++ b/src/engine/graphic/GRVoiceManager.cpp
@@ -200,6 +200,8 @@ GRVoiceManager::GRVoiceManager(GRMusic* music, GRStaffManager * p_staffmgr, cons
 	voicenum = p_voicenum;
 	mCurGrStaff = NULL;
 	grvoice = fMusic->getVoice(arVoice);
+	mVoiceClefTime = DURATION_0;
+	mVoiceClefTimeSet = false;
 
 	fLastOctava = NULL;
 	fGRTags = NULL;
@@ -285,6 +287,8 @@ bool GRVoiceManager::parseStateTag(const ARMusicalTag * mtag)
 		// until this voice sets a new one.
 		fVoiceState->RemoveCurStateTag(typeid(ARClef));
 		mHasVoiceClefTag = false;
+		mVoiceClefTimeSet = false;
+		mVoiceClefTime = DURATION_0;
 	}
 	else if ((staffrmt = dynamic_cast<const ARStaffFormat *>(mtag)) != 0)
 		mCurGrStaff->setStaffFormat(staffrmt);
@@ -932,6 +936,8 @@ GRNotationElement * GRVoiceManager::parseTag(ARMusicalObject * arOfCompleteObjec
 	{
 		grne = mCurGrStaff->AddClef(static_cast<const ARClef *>(arOfCompleteObject));
 		mHasVoiceClefTag = true;
+		mVoiceClefTime = arOfCompleteObject->getRelativeTimePosition();
+		mVoiceClefTimeSet = true;
 		
 		// here the baseline etc. will be changed
 		if (grne) fMusic->addVoiceElement(arVoice,grne);
@@ -1952,6 +1958,7 @@ GRSingleNote * GRVoiceManager::CreateSingleNote( const TYPE_TIMEPOSITION & tp, A
 	curev = ARMusicalEvent::cast(arObject);
 
 	TYPE_DURATION dtempl = findDuration (fVoiceState, curev);
+	const TYPE_TIMEPOSITION noteStart = arObject->getRelativeTimePosition();
 
 	// we need to take care of dots !
 	const ARNote * tmpNote = static_cast<const ARNote *>(curev->isARNote());
@@ -1963,22 +1970,32 @@ GRSingleNote * GRVoiceManager::CreateSingleNote( const TYPE_TIMEPOSITION & tp, A
 	int baseLine = staffState.getBaseLine();
 	int baseOct = staffState.getBaseOctave();
 
-	if (mHasVoiceClefTag) {
-		// Only override the staff clef when this voice has explicitly set one.
-		if (ARMusicalTag * clefTag = fVoiceState->getCurStateTag(typeid(ARClef))) {
-			if (const ARClef * voiceClef = dynamic_cast<const ARClef *>(clefTag)) {
-				if (!voiceClef->getIsAuto()) {
-					GRClef tmpClef(voiceClef, mCurGrStaff);
-					basePitch = tmpClef.getBasePitch() + staffState.getBasePitchOffset();
-					baseLine = tmpClef.getBaseLine();
-					baseOct = tmpClef.getBaseOct();
-				}
-			}
+	const ARClef* voiceClef = nullptr;
+	TYPE_TIMEPOSITION voiceClefTime = mVoiceClefTime;
+	if (ARMusicalTag * clefTag = fVoiceState->getCurStateTag(typeid(ARClef))) {
+		voiceClef = dynamic_cast<const ARClef *>(clefTag);
+		if (voiceClef) {
+			voiceClefTime = voiceClef->getRelativeTimePosition();
 		}
+	}
+
+	bool useVoiceClef = mHasVoiceClefTag && voiceClef;
+	if (useVoiceClef && staffState.hasClefTime()) {
+		const TYPE_TIMEPOSITION& staffClefTime = staffState.getClefTime();
+		if ((staffClefTime >= voiceClefTime) && (staffClefTime <= noteStart)) {
+			useVoiceClef = false;
+		}
+	}
+
+	if (useVoiceClef && voiceClef && !voiceClef->getIsAuto()) {
+		GRClef tmpClef(voiceClef, mCurGrStaff);
+		basePitch = tmpClef.getBasePitch() + staffState.getBasePitchOffset();
+		baseLine = tmpClef.getBaseLine();
+		baseOct = tmpClef.getBaseOct();
 	}
 	// Voice without its own clef: keep using the staff's initial clef so later
 	// clef changes in other voices don't shift this voice's pitches.
-	else if (staffState.hasInitialClef()) {
+	else if (!mHasVoiceClefTag && staffState.hasInitialClef()) {
 		basePitch = staffState.getInitialBasePitch();
 		baseLine = staffState.getInitialBaseLine();
 		baseOct = staffState.getInitialBaseOctave();

--- a/src/engine/graphic/GRVoiceManager.h
+++ b/src/engine/graphic/GRVoiceManager.h
@@ -169,6 +169,7 @@ private:
 	GROctava*				fLastOctava;
 	ARMusicalVoiceState *	fVoiceState;
 	bool					mHasVoiceClefTag = false;
+	bool					mHasExplicitVoiceClef = false;
 	bool					mVoiceClefTimeSet = false;
 	TYPE_TIMEPOSITION		mVoiceClefTime = DURATION_0;
 	GRTagPointerList *		fGRTags;

--- a/src/engine/graphic/GRVoiceManager.h
+++ b/src/engine/graphic/GRVoiceManager.h
@@ -169,6 +169,8 @@ private:
 	GROctava*				fLastOctava;
 	ARMusicalVoiceState *	fVoiceState;
 	bool					mHasVoiceClefTag = false;
+	bool					mVoiceClefTimeSet = false;
+	TYPE_TIMEPOSITION		mVoiceClefTime = DURATION_0;
 	GRTagPointerList *		fGRTags;
 	GRTrill*				fCurrentTrill = 0;
 	


### PR DESCRIPTION
This PR fixes new regressions (or even maybe prior bugs) related to #196 and #95 and reported in `open-issues/g-issue196-2.gmn` and `open-issues/g-issue196-3.gmn`.

We now simply track a `clefHistory` in the `StaffState` and recall it on each staff creation for the same voice to infer context.

When merged, we can move the two open-issues to regression-tests.